### PR TITLE
Sidebar body toggle

### DIFF
--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -29,12 +29,15 @@
         this.$root.$emit('hide::notificationsdropdown')
         this.$root.$emit('hide::profiledropdown')
         this.$root.$emit('maVue::hide::sidebar')
-        this.sidebarOpen = !this.sidebarOpen
       }
     },
     created () {
       this.$root.$on('maVue::collapseSidebar', () => {
         this.sidebarOpen = !this.sidebarOpen
+      })
+
+      this.$root.$on('maVue::hide::sidebar', () => {
+        this.sidebarOpen = false
       })
     }
   }


### PR DESCRIPTION
Fixes #21 By ensuring a body click event only causes the sidebar to close not invert the boolean for sidebar being open ensuring it doesn't open the sidebar when the body is being clicked.