### PR TITLE
Sidebar dropdown toggle events

### DIFF
--- a/src/components/sidebar/nav/SidebarNavDropdown.vue
+++ b/src/components/sidebar/nav/SidebarNavDropdown.vue
@@ -1,7 +1,7 @@
 <template>
 
 <li :class="{active: isActive, open: show}">
-  <a href="#" v-on:click.stop.prevent="toggle(e)">
+  <a href="#" v-on:click.stop.prevent="toggle">
     <i class="fa" :class="[icon]"></i>
     {{ itemText }}
     <i class="fa arrow"></i>
@@ -38,7 +38,7 @@
       }
     },
     methods: {
-      toggle (e) {
+      toggle () {
         this.show = !this.show
       }
     },


### PR DESCRIPTION
Removes console errors for unknown e that is passed as a paramter when clicking on the dropdown.